### PR TITLE
[WIP] Postgres proof of concept for Nassau's algorithm

### DIFF
--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -18,7 +18,7 @@ sseq = { path = "crates/sseq", default-features = false }
 adler = "1"
 
 anyhow = "1.0.0"
-postgres = { version = "0.19.3", optional = true }
+r2d2_postgres = { version = "0.18.1", optional = true }
 rayon = { version = "1.5", optional = true }
 rustc-hash = "1.1.0"
 serde_json = { version = "1.0.0", features = ["preserve_order"] }
@@ -45,7 +45,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["odd-primes"]
 cache-multiplication = ["algebra/cache-multiplication"]
 concurrent = ["rayon", "once/concurrent", "fp/concurrent", "algebra/concurrent"]
-database = ["postgres"]
+database = ["r2d2_postgres"]
 odd-primes = ["fp/odd-primes", "algebra/odd-primes", "sseq/odd-primes"]
 logging = []
 nassau = []

--- a/ext/Cargo.toml
+++ b/ext/Cargo.toml
@@ -18,6 +18,7 @@ sseq = { path = "crates/sseq", default-features = false }
 adler = "1"
 
 anyhow = "1.0.0"
+postgres = { version = "0.19.3", optional = true }
 rayon = { version = "1.5", optional = true }
 rustc-hash = "1.1.0"
 serde_json = { version = "1.0.0", features = ["preserve_order"] }
@@ -44,6 +45,7 @@ crate-type = ["cdylib", "rlib"]
 default = ["odd-primes"]
 cache-multiplication = ["algebra/cache-multiplication"]
 concurrent = ["rayon", "once/concurrent", "fp/concurrent", "algebra/concurrent"]
+database = ["postgres"]
 odd-primes = ["fp/odd-primes", "algebra/odd-primes", "sseq/odd-primes"]
 logging = []
 nassau = []

--- a/ext/examples/nassau_with_db.rs
+++ b/ext/examples/nassau_with_db.rs
@@ -1,0 +1,30 @@
+/// This is essentially a copy of `resolve_through_stem` using a database instead of files.
+///
+/// This is for testing purposes only, and should be removed before merging the database feature
+/// branch into `master`.
+use core::str::FromStr;
+
+use ext::{chain_complex::FreeChainComplex, save::SaveTarget, utils, utils::construct_nassau};
+
+fn main() -> anyhow::Result<()> {
+    let (name, module): (String, utils::Config) = query::with_default("Module", "S_2", |s| {
+        Result::<_, anyhow::Error>::Ok((s.to_owned(), s.try_into()?))
+    });
+
+    let save_target = query::optional(
+        "Connection string in the sense of https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING",
+        |s| postgres::Config::from_str(&s).map(SaveTarget::from),
+    );
+
+    let mut res = construct_nassau(module, save_target)?;
+    res.set_name(name);
+
+    let max_n = query::with_default("Max n", "30", str::parse);
+    let max_s = query::with_default("Max s", "15", str::parse);
+
+    res.compute_through_stem(max_s, max_n);
+
+    println!("{}", res.graded_dimension_string());
+
+    Ok(())
+}

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -1,5 +1,6 @@
 use byteorder::{LittleEndian, ReadBytesExt, WriteBytesExt};
 use std::collections::HashSet;
+use std::convert::From;
 use std::fs::File;
 use std::io::{BufRead, BufReader, BufWriter, Error, ErrorKind, Read, Write};
 use std::path::PathBuf;
@@ -7,6 +8,34 @@ use std::sync::{Arc, Mutex};
 
 use algebra::Algebra;
 use anyhow::Context;
+
+/// An `enum` with a variant for each method of saving data
+pub enum SaveBackend<Dir> {
+    /// Use files in a directory
+    Directory(Dir),
+}
+
+impl<Dir> SaveBackend<Dir> {
+    pub fn as_ref(&self) -> SaveBackend<&Dir> {
+        match self {
+            SaveBackend::Directory(dir) => SaveBackend::Directory(dir),
+        }
+    }
+    pub fn as_mut(&mut self) -> SaveBackend<&mut Dir> {
+        match self {
+            SaveBackend::Directory(dir) => SaveBackend::Directory(dir),
+        }
+    }
+}
+
+/// A specialized version of [SaveBackend] that is used to describe where data should be written
+pub type SaveTarget = SaveBackend<PathBuf>;
+
+impl From<PathBuf> for SaveTarget {
+    fn from(p: PathBuf) -> Self {
+        SaveBackend::Directory(p)
+    }
+}
 
 /// A DashSet<PathBuf>> of files that are currently opened and being written to. When calling this
 /// function for the first time, we set the ctrlc handler to delete currently opened files, then

--- a/ext/src/save.rs
+++ b/ext/src/save.rs
@@ -262,7 +262,7 @@ impl SaveKind {
                         id BIGSERIAL PRIMARY KEY NOT NULL,
                         s OID NOT NULL,
                         t INT NOT NULL,
-                        command BIGINT NOT NULL,
+                        magic BIGINT NOT NULL,
                         FOREIGN KEY (s, t)
                             REFERENCES nassau_qi.metadata(s,t) ON DELETE CASCADE
                     );

--- a/ext/src/utils.rs
+++ b/ext/src/utils.rs
@@ -4,6 +4,7 @@ use crate::chain_complex::{
 };
 
 use crate::resolution::{Resolution, UnstableResolution};
+use crate::save::SaveTarget;
 use crate::CCC;
 use algebra::module::{steenrod_module, FDModule, Module, SteenrodModule};
 use algebra::{AlgebraType, MilnorAlgebra, SteenrodAlgebra};
@@ -144,7 +145,7 @@ where
 {
     #[cfg(feature = "nassau")]
     {
-        construct_nassau(module_spec, save_dir)
+        construct_nassau(module_spec, save_dir.map(SaveTarget::from))
     }
 
     #[cfg(not(feature = "nassau"))]
@@ -156,7 +157,7 @@ where
 /// See [`construct`]
 pub fn construct_nassau<T, E>(
     module_spec: T,
-    save_dir: Option<PathBuf>,
+    save_dir: Option<SaveTarget>,
 ) -> anyhow::Result<crate::nassau::Resolution<FDModule<MilnorAlgebra>>>
 where
     anyhow::Error: From<E>,
@@ -448,7 +449,7 @@ pub fn get_unit(
         {
             Arc::new(crate::nassau::Resolution::new_with_save(
                 Arc::new(module),
-                save_dir,
+                save_dir.map(SaveTarget::from),
             )?)
         }
 


### PR DESCRIPTION
This branch adds a (Cargo) feature `database` which should enable saving data in a database. It is incomplete and not intended to be merged, and this PR exists to discuss the implementation.  So far, database saves are only implemented for Nassau''s algorithm (i.e. the `NassauDifferential` and `NassauQi` `SaveKind`s).

There is an example binary `nassau_with_db` (which requires the `nassau` and `database` features) that works similarly to `resolve_through_stem`, but takes a [connection string](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING) instead of a path.

# Some comments on the implementation

Unfortunately, it is not really feasible to write the database saving mechanism as a drop-in replacement for the file saving mechanism: The file mechanism essentially only exposes handles for writing or reading binary data and doesn't "know" what the data contains, whereas when using a database one would like to have more knowledge about what kind of data is being written to figure out to which table to insert the data.

In order to deal with file and database saves on an equal footing, I introduced a `SaveBackend` enum which contains a variant for files and, if the `database` feature is enabled, another variant for the database. Then, I basically replaced every usage of a path or file handle with a `match` block which deals with the database case as well. This is admittedly rather finicky, especially because different save mechanisms use different kinds of "local state", but the alternative of guarding functions/blocks with `#[cfg(..)]` directives would lead to a lot of code duplication because saving is so intertwined with code that actually "does non-trivial work". (I think a conceptual solution for this could be having a trait like `Save$X` for each `SaveKind` `X` that describes the steps needed to (de)serialize that `SaveKind`, and implementing these traits for file and database backends.)

Here are some other more minor design choices I made that potentially need rethinking.

* For now, `FpVector`s are simply dumped using `to_bytes`. (I didn't put too much effort into this because it might need changes after the vector rewrite anyway.)
* A save directory for a module roughly corresponds to a database connection configuration, so the users are expected to use different databases (e.g. `dbname`s in the connection string) for different modules.
* A save kind corresponds to a schema. Schema names are currently hard coded, but it might be better to use the result of `SaveKind::name` at the cost of adding a formatting macro for each query string.
* In order to guarantee data integrity, each "block" of data that corresponds to a single file in the file saving mechanism is written in a single database transaction. Especially for `NassauQi`s, these transactions can take a long time and I am not sure if it is reasonable to keep a connection/transaction open for such a long time.